### PR TITLE
add pre defined meta for whole api and add unit test for this part

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,28 +11,31 @@ declare global {
   }
 }
 
-const responseEnhancer = () => (
+const responseEnhancer = (definedMeta?: any) => (
   req: Request,
   res: Response,
   next: NextFunction,
 ): void => {
-  res.formatter = _generateFormatters(res)
+  res.formatter = _generateFormatters(res, definedMeta)
   next()
 }
 
-const _generateFormatters = (res: Response) => {
+const _generateFormatters = (res: Response, definedMeta?: any) => {
   const formatter = {} as ResponseFunction
+  let responseMeta = {}
   let responseBody = {}
 
   methods.map((method: Method) => {
     if (method.isSuccess) {
       formatter[method.name] = (data: any, meta: any) => {
-        responseBody = _generateSuccessResponse({ data, meta })
+        responseMeta = meta ? meta : definedMeta
+        responseBody = _generateSuccessResponse({ data, meta: responseMeta })
         res.status(parseInt(method.code)).json(responseBody)
       }
     } else {
       formatter[method.name] = (error: any, meta: any) => {
-        responseBody = _generateErrorResponse({ error, meta })
+        responseMeta = meta ? meta : definedMeta
+        responseBody = _generateErrorResponse({ error, meta: responseMeta })
         res.status(parseInt(method.code)).json(responseBody)
       }
     }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,13 +6,24 @@ const app = express()
 
 describe('Test avaliable methods.', () => {
   beforeAll(() => {
-    app.use(responseEnhancer())
+    const definedMEta = {
+      version: '1.0',
+      env: 'dev',
+    }
+    app.use(responseEnhancer(definedMEta))
 
     app.get('/success-with-meta', function(req, res) {
       const users = [{ name: 'John' }, { name: 'Jane' }]
       const metadata = { total: 2 }
 
       res.formatter.ok(users, metadata)
+    })
+
+    app.get('/success-with-defined-meta', function(req, res) {
+      const users = [{ name: 'John' }, { name: 'Jane' }]
+      // const metadata = { total: 2 }
+
+      res.formatter.ok(users)
     })
 
     app.get('/not-found', function(req, res) {
@@ -50,6 +61,25 @@ describe('Test avaliable methods.', () => {
         expect(res.body).toEqual({
           meta: { trackId: '12345' },
           error: [{ detail: 'User not found.', message: 'NOT_FOUND' }],
+        })
+        done()
+      })
+  })
+
+  it('"formatter.notFound" should return status code "404" and correct payload', done => {
+    request(app)
+      .get('/success-with-defined-meta')
+      .set('Accept', 'application/json')
+      .expect('Content-Type', /json/)
+      .expect(200)
+      .end((err, res) => {
+        if (err) return done(err)
+        expect(res.body).toEqual({
+          data: [{ name: 'John' }, { name: 'Jane' }],
+          meta: {
+            version: '1.0',
+            env: 'dev',
+          },
         })
         done()
       })


### PR DESCRIPTION
I added an option to provide a pre-defined meta for the whole API at the register middleware phase. 

For Example
```
const meta = {
   version : "1.0",
   env :  "dev"
}
app.use(responseEnhancer(meta))

```